### PR TITLE
Prevent loading of empty pickle file (which causes Aborted!)

### DIFF
--- a/pylivetrader/statestore/__init__.py
+++ b/pylivetrader/statestore/__init__.py
@@ -40,7 +40,7 @@ class StateStore:
             pickle.dump(state, f)
 
     def load(self, context, checksum):
-        if not os.path.exists(self.path):
+        if not os.path.exists(self.path) or not os.stat(self.path).st_size:
             return
 
         with open(self.path, 'rb') as f:


### PR DESCRIPTION
I ran into an issue where the pkl file ended up being zero size, in this condition the `pylivetrader` command simply printed the exceptionally helpful 'Aborted!' which comes from click Exception handling.

I'm not sure why I didn't see a stack trace in this instance.

Similar to #62, loading of this pickle file may need to be a little more robust, but for now I just prevented attempts at loading of the empty file.  
