### PR TITLE
Support storage of state in redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The options are as follows.
 - `-f` or `--file`: the file path to the algorithm source
 - `-b` or `--backend`: the name of backend to use
 - `--backend-config`: the yaml file for backend parameters
+- `--storage-engine`: the storage engine to use for persisting the context. ('file' or 'redis')
 - `-s` or `--statefile`: the file path to the persisted state file (look for the State Management section below)
 - `-r` or `--retry`: the algorithm runner continues execution in the event a general exception is raised
 - `-l` or `--log-level`: the minimum level of log which will be written ('DEBUG', 'INFO', 'WARNING', 'ERROR', or 'CRITICAL')

--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ If you are running pylivetrader in an environment with an ephemeral file store a
 to persist across restarts, you can use the redis storage engine. This is useful if you launch in a
 place like heroku.
 
-To use this, everything is the same as above, except the `run` command looks like the following:
+To use this, you must install the redis-py library.
+
+```sh
+$ pip install redis
+```
+
+After that everything is the same as above, except the `run` command looks like the following:
 
 ```sh
 $ pylivetrader run -f algo.py --backend-config config.yaml --storage-engine redis

--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ key_id: BROKER_API_KEY
 secret: BROKER_SECRET
 ```
 
+### Usage with redis
+
+If you are running pylivetrader in an environment with an ephemeral file store and need your context
+to persist across restarts, you can use the redis storage engine. This is useful if you launch in a
+place like heroku.
+
+To use this, everything is the same as above, except the `run` command looks like the following:
+
+```sh
+$ pylivetrader run -f algo.py --backend-config config.yaml --storage-engine redis
+```
+
+Assuming you have redis running, this will now serialize your context object to and from redis.
+
 ## Installation
 
 Install with pip. **pylivetrader currently supports Python 3.5, 3.6 and 3.7+**

--- a/pylivetrader/__main__.py
+++ b/pylivetrader/__main__.py
@@ -83,6 +83,12 @@ def algo_parameters(f):
             show_default=True,
             help='The minimum level of log to be written.'),
         click.option(
+            '--storage-engine',
+            type=click.Choice({'file', 'redis'}),
+            default='file',
+            show_default=True,
+            help='The storage engine to use to persist context.'),
+        click.option(
             '-q', '--quantopian-compatible',
             default=True,
             type=bool,
@@ -106,6 +112,7 @@ def process_algo_params(
         statefile,
         retry,
         log_level,
+        storage_engine,
         quantopian_compatible):
     if len(algofile) > 0:
         algofile = algofile[0]
@@ -134,6 +141,7 @@ def process_algo_params(
         algoname=extract_filename(algofile),
         statefile=statefile,
         log_level=log_level,
+        storage_engine=storage_engine,
         quantopian_compatible=quantopian_compatible,
         **functions,
     )

--- a/pylivetrader/statestore/__init__.py
+++ b/pylivetrader/statestore/__init__.py
@@ -17,14 +17,67 @@
 import pickle
 import os
 
+try:
+    from redis import Redis
+except ImportError:
+    pass
+
 VERSION_LABEL = '_stateversion_'
 CHECKSUM_KEY = '__state_checksum'
 
+class FileStore(object):
+    def __init__(self, path):
+        self.path = path
+
+    def save(self, state):
+        with open(self.path, 'wb') as f:
+            pickle.dump(state, f)
+
+    def load(self):
+        with open(self.path, 'rb') as f:
+            try:
+                loaded_state = pickle.load(f)
+            except (pickle.UnpicklingError, IndexError):
+                raise ValueError("Corrupt state file: {}".format(self.path))
+
+        return loaded_state
+
+    def can_load(self):
+        return os.path.exists(self.path) and os.stat(self.path).st_size
+
+class RedisStore(object):
+    REDIS_STATE_KEY = 'pylivetrader_redis_state'
+
+    def __init__(self):
+        try:
+            Redis
+        except NameError:
+            raise ValueError("Redis was not installed, please install the redis module.")
+
+        self.redis = Redis()
+
+    def save(self, state):
+        self.redis.set(self.REDIS_STATE_KEY, pickle.dumps(state))
+
+    def load(self):
+        try:
+            loaded_state = pickle.loads(self.redis.get(self.REDIS_STATE_KEY))
+            return loaded_state
+        except pickle.UnpicklingError:
+            raise ValueError("Corrupt state file in redis")
+
+    def can_load(self):
+        return self.redis.exists(self.REDIS_STATE_KEY)
 
 class StateStore:
 
-    def __init__(self, path):
-        self.path = path
+    def __init__(self, path=None, storage_engine=None):
+        if path:
+            self.storage_engine = FileStore(path)
+        elif storage_engine:
+            self.storage_engine = storage_engine
+        else:
+            raise ValueError("path or storage_engine arg is required")
 
     def save(self, context, checksum, exclude_list):
         state = {}
@@ -36,18 +89,13 @@ class StateStore:
 
         state[CHECKSUM_KEY] = checksum
 
-        with open(self.path, 'wb') as f:
-            pickle.dump(state, f)
+        self.storage_engine.save(state)
 
     def load(self, context, checksum):
-        if not os.path.exists(self.path) or not os.stat(self.path).st_size:
+        if not self.storage_engine.can_load():
             return
 
-        with open(self.path, 'rb') as f:
-            try:
-                loaded_state = pickle.load(f)
-            except (pickle.UnpicklingError, IndexError):
-                raise ValueError("Corrupt state file: {}".format(self.path))
+        loaded_state = self.storage_engine.load()
 
         if CHECKSUM_KEY not in loaded_state or \
                 loaded_state[CHECKSUM_KEY] != checksum:

--- a/pylivetrader/statestore/__init__.py
+++ b/pylivetrader/statestore/__init__.py
@@ -18,7 +18,7 @@ import pickle
 import os
 
 try:
-    from redis import Redis
+    import redis
 except ImportError:
     pass
 
@@ -50,11 +50,11 @@ class RedisStore(object):
 
     def __init__(self):
         try:
-            Redis
+            redis
         except NameError:
             raise ValueError("Redis was not installed, please install the redis module.")
 
-        self.redis = Redis()
+        self.redis = redis.from_url(os.getenv('REDIS_URL', 'redis://localhost:6379'))
 
     def save(self, state):
         self.redis.set(self.REDIS_STATE_KEY, pickle.dumps(state))

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,7 @@ setup(
         'pytest-cov',
     ],
     setup_requires=["flake8", "pytest-runner"],
-    extras_require={}
+    extras_require={
+        "redis": ["redis"]
+    }
 )


### PR DESCRIPTION
I am currently running my algo within heroku as a docker image. Heroku provides ephemeral storage on the instances running the containers, which means my context is wiped every time the contrainer restarts (every 24 hours minimum on heroku). I needed the support for storing my context in a place that I could easily configure in heroku.

This PR adds support for redis and enables support for about any other storage provider someone might need.

I am very new to python, so please let me know if I didn't follow any common practices or otherwise, all the tests passed and running `python3 setup.py test --extras` passes with the redis library installed as well.