### PR TITLE
Handle empty bardata and update pipeline-live version

### DIFF
--- a/dockerfiles/Pipfile
+++ b/dockerfiles/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 numpy = ">1.16"
 alpaca-trade-api = "==0.28"
-pylivetrader = "==0.0.30"
+pylivetrader = "==0.0.29"
 pipeline-live = "==0.1.5"
 ta-lib = "==0.4.17"
 

--- a/dockerfiles/Pipfile
+++ b/dockerfiles/Pipfile
@@ -6,8 +6,8 @@ name = "pypi"
 [packages]
 numpy = ">1.16"
 alpaca-trade-api = "==0.28"
-pylivetrader = "==0.0.29"
-pipeline-live = "==0.1.4"
+pylivetrader = "==0.0.30"
+pipeline-live = "==0.1.5"
 ta-lib = "==0.4.17"
 
 [dev-packages]

--- a/pylivetrader/_version.py
+++ b/pylivetrader/_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = '0.0.30'
+VERSION = '0.0.29'

--- a/pylivetrader/_version.py
+++ b/pylivetrader/_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = '0.0.29'
+VERSION = '0.0.30'

--- a/pylivetrader/backend/alpaca.py
+++ b/pylivetrader/backend/alpaca.py
@@ -600,11 +600,12 @@ class Backend(BaseBackend):
             if size == 'minute':
                 df.index += pd.Timedelta('1min')
 
-                # mask out bars outside market hours
-                mask = self._cal.minutes_in_range(
-                    df.index[0], df.index[-1],
-                ).tz_convert(NY)
-                df = df.reindex(mask)
+                if not df.empty:
+                    # mask out bars outside market hours
+                    mask = self._cal.minutes_in_range(
+                        df.index[0], df.index[-1],
+                    ).tz_convert(NY)
+                    df = df.reindex(mask)
 
             if limit is not None:
                 df = df.iloc[-limit:]

--- a/pylivetrader/data/bardata.py
+++ b/pylivetrader/data/bardata.py
@@ -123,6 +123,9 @@ class BarData:
 
     def history(self, assets, fields, bar_count, frequency):
 
+        if not assets and fields:
+            return None
+
         if isinstance(fields, str):
             single_asset = isinstance(assets, Asset)
 

--- a/pylivetrader/data/bardata.py
+++ b/pylivetrader/data/bardata.py
@@ -123,7 +123,7 @@ class BarData:
 
     def history(self, assets, fields, bar_count, frequency):
 
-        if not assets and fields:
+        if not (assets and fields):
             return None
 
         if isinstance(fields, str):


### PR DESCRIPTION
A user found that calling `data.current(symbol('UJB'))` was consistently resulting in errors because of a lack of data on the symbol from Polygon. Now, an empty dataframe will be returned rather than an error. Also, iexfinance released an update which breaks pipeline-live's previous version, so I'm updating the dockerhub dependency to point to its current version.