### PR TITLE
alpaca.py timestamp to datetime conversion fix

### DIFF
--- a/pylivetrader/_version.py
+++ b/pylivetrader/_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = '0.0.29'
+VERSION = '0.0.30'


### PR DESCRIPTION
The current version does not work with `USEquityPricing` provided by Alpaca due to improper timestamp conversion to date times.