### PR TITLE
Validate BarData data_frequency arg

### DIFF
--- a/pylivetrader/data/bardata.py
+++ b/pylivetrader/data/bardata.py
@@ -40,7 +40,11 @@ def _is_iterable(d):
 
 class BarData:
 
-    def __init__(self, data_portal, data_frequency):
+    def __init__(self, data_portal, data_frequency: str):
+
+        # Validate data_frequency arg
+        if data_frequency not in ['minute', 'daily']:
+            raise ValueError(f'BarData: Invalid `data_frequency` {data_frequency}')
 
         self.data_portal = data_portal
         self.data_frequency = data_frequency


### PR DESCRIPTION
#### Summary

This PR addresses adds type validation for `BarData(..., data_frequency)`.  The nonexistence of `data_frequency` will cause `bardata.py:77` to raise a `TypeError` (not withstanding `:86` which is unreachable due to `:54` and should be deprecated).  This error was brought up by user Dung Nguyen on the Alpaca Community Slack.

```bash
File "/home/user/anaconda3/envs/pyenv/lib/python3.6/site-packages/pylivetrader/data/bardata.py", line 82, in fetch
   self.data_frequency
TypeError: get_adjusted_value() missing 1 required positional argument: 'data_frequency'
```

The full stack trace can be found [here](https://pastebin.com/pj3QwBcw).

This nonexistence should not be allowed to percolate into `BarData.current` and is thus raised as an exception within instantiation.  

#### Known Issues

I have not spent much time in the library, but from what I have seen, Py3 type declarations and type checking are absent.  As such, this PR breaks from convention. 

#### Testing

I am unable to replicate the original issue myself (lack of access to the invoking script) and have not tested whether this helps to alleviate the aforementioned problem.