### PR TITLE
Add pipeline hook

### DIFF
--- a/pylivetrader/algorithm.py
+++ b/pylivetrader/algorithm.py
@@ -116,6 +116,7 @@ class Algorithm(object):
         before_trading_start: before_trading_start function
         log_level: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
         storage_engine: 'file', 'redis'
+        pipeline_hook: pipeline_output hook function
         '''
         log.level = lookup_level(kwargs.pop('log_level', 'INFO'))
         self._recorded_vars = {}
@@ -212,6 +213,8 @@ class Algorithm(object):
         self.api_methods = [func for func in dir(Algorithm) if callable(
             getattr(Algorithm, func)
         )]
+
+        self._pipeline_hook = kwargs.pop('pipeline_hook')
 
     def initialize(self, *args, **kwargs):
         self._context_persistence_excludes = (
@@ -1062,6 +1065,9 @@ class Algorithm(object):
 
     @api_method
     def pipeline_output(self, name):
+        if self._pipeline_hook is not None:
+            return self._pipeline_hook(self, name)
+
         try:
             from pipeline_live.engine import LivePipelineEngine
         except ImportError:

--- a/pylivetrader/algorithm.py
+++ b/pylivetrader/algorithm.py
@@ -214,7 +214,7 @@ class Algorithm(object):
             getattr(Algorithm, func)
         )]
 
-        self._pipeline_hook = kwargs.pop('pipeline_hook')
+        self._pipeline_hook = kwargs.get('pipeline_hook')
 
     def initialize(self, *args, **kwargs):
         self._context_persistence_excludes = (

--- a/pylivetrader/testing/smoke/harness.py
+++ b/pylivetrader/testing/smoke/harness.py
@@ -52,13 +52,8 @@ def run_smoke(algo, before_run_hook=None, pipeline_hook=None):
         handle_data=getattr(algo, 'handle_data', noop),
         before_trading_start=getattr(algo, 'before_trading_start', noop),
         backend=be,
+        pipeline_hook=pipeline_hook
     )
-
-    if pipeline_hook is not None:
-        def _pipeline_output(name):
-            return pipeline_hook.output(a, name)
-
-        a.pipeline_output = _pipeline_output
 
     with LiveTraderAPI(a), \
             patch('pylivetrader.executor.executor.RealtimeClock') as rc:


### PR DESCRIPTION
This PR addresses the issue #119 -- smoke tests broken.  I think it's ok to pass the hook function as an optional keyword argument.  I could add a setter `set_pipeline_hook(self, pipeline_hook)` but I didn't want to introduce another api method.