### PR TITLE
Don't yield BAR at session end - market already closed

### DIFF
--- a/pylivetrader/executor/realtimeclock.py
+++ b/pylivetrader/executor/realtimeclock.py
@@ -109,7 +109,6 @@ class RealtimeClock(object):
                     sleep(1)
             elif server_time == session_close:
                 self._last_emit = server_time
-                yield server_time, BAR
                 if self.minute_emission:
                     yield server_time, MINUTE_END
                 yield server_time, SESSION_END


### PR DESCRIPTION
this is a fix for https://github.com/alpacahq/pylivetrader/issues/128

at session end we should not emit a BAR signal (which in turn calls handle_data) since the market is already closed. 

this code was inspired by zipline and zipline-live
the MINUTE_END and SESSION_END signals are used for performance metricses which are not utilized in this project yet.
also, zipline-live stops running everyday at market close so there is no re-signalling the entire minute like it is done here.

we may think of removing these signals since they are not used or make sure they are sent once. 