### PR TITLE
Set the data.datetime property for the shell

### DIFF
--- a/pylivetrader/shell.py
+++ b/pylivetrader/shell.py
@@ -9,4 +9,5 @@ def start_shell(algorithm, algomodule):
         algorithm.data_portal,
         algorithm.data_frequency)
     algorithm.on_dt_changed(pd.Timestamp.utcnow().floor('1min'))
+    algomodule['data'].datetime = algorithm.datetime
     InteractiveShellEmbed()('*** pylivetrader shell ***', local_ns=algomodule)


### PR DESCRIPTION
some of the data object methods rely on the datetime property.
but it is not set because the algorithm is not running.
by doing this, we set the time to be the current time, allowing those methods to work (e.g data.can_trade())
this resolves: https://github.com/alpacahq/pylivetrader/issues/133
