### PR TITLE
Zipline throws AttributeError with bottleneck v1.0.0, need to upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     pylivetrader=pylivetrader.__main__:main
     ''',
     install_requires=[
-        'bottleneck==1.0.0',
+        'bottleneck',
         'pandas<0.23',
         'pytz',
         'logbook',


### PR DESCRIPTION
zipline 1.3.0 tries to do this bottleneck.nanmean which throws AttributeError because bottleneck version 1.0.0 doesn't have that attribute. 
upgrading it to the latest version fixes this issue. 