### PR TITLE
Pipeline output hook to re-enable the smoke tool

### DIFF
--- a/pylivetrader/algorithm.py
+++ b/pylivetrader/algorithm.py
@@ -116,6 +116,7 @@ class Algorithm(object):
         before_trading_start: before_trading_start function
         log_level: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
         storage_engine: 'file', 'redis'
+        pipeline_hook: pipeline_output hook function
         '''
         log.level = lookup_level(kwargs.pop('log_level', 'INFO'))
         self._recorded_vars = {}
@@ -212,6 +213,8 @@ class Algorithm(object):
         self.api_methods = [func for func in dir(Algorithm) if callable(
             getattr(Algorithm, func)
         )]
+
+        self._pipeline_hook = kwargs.get('pipeline_hook')
 
     def initialize(self, *args, **kwargs):
         self._context_persistence_excludes = (
@@ -1064,6 +1067,9 @@ class Algorithm(object):
 
     @api_method
     def pipeline_output(self, name):
+        if self._pipeline_hook is not None:
+            return self._pipeline_hook(self, name)
+
         try:
             from pipeline_live.engine import LivePipelineEngine
         except ImportError:

--- a/pylivetrader/algorithm.py
+++ b/pylivetrader/algorithm.py
@@ -116,8 +116,8 @@ class Algorithm(object):
         before_trading_start: before_trading_start function
         log_level: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
         storage_engine: 'file', 'redis'
-        pipeline_hook: pipeline_output hook function to enable smoke like 
-                       functionality. it is not meant to be used by the 
+        pipeline_hook: pipeline_output hook function to enable smoke like
+                       functionality. it is not meant to be used by the
                        CLI
         '''
         log.level = lookup_level(kwargs.pop('log_level', 'INFO'))
@@ -215,7 +215,7 @@ class Algorithm(object):
 
         self.api_methods = [func for func in dir(Algorithm) if callable(
             getattr(Algorithm, func)
-        )]        
+        )]
 
     def initialize(self, *args, **kwargs):
         self._context_persistence_excludes = (

--- a/pylivetrader/algorithm.py
+++ b/pylivetrader/algorithm.py
@@ -116,7 +116,9 @@ class Algorithm(object):
         before_trading_start: before_trading_start function
         log_level: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
         storage_engine: 'file', 'redis'
-        pipeline_hook: pipeline_output hook function
+        pipeline_hook: pipeline_output hook function to enable smoke like 
+                       functionality. it is not meant to be used by the 
+                       CLI
         '''
         log.level = lookup_level(kwargs.pop('log_level', 'INFO'))
         self._recorded_vars = {}

--- a/pylivetrader/algorithm.py
+++ b/pylivetrader/algorithm.py
@@ -189,6 +189,7 @@ class Algorithm(object):
         self._initialize = kwargs.pop('initialize', noop)
         self._handle_data = kwargs.pop('handle_data', noop)
         self._before_trading_start = kwargs.pop('before_trading_start', noop)
+        self._pipeline_hook = kwargs.get('pipeline_hook')
 
         self.event_manager.add_event(
             events.Event(
@@ -214,9 +215,7 @@ class Algorithm(object):
 
         self.api_methods = [func for func in dir(Algorithm) if callable(
             getattr(Algorithm, func)
-        )]
-
-        self._pipeline_hook = kwargs.get('pipeline_hook')
+        )]        
 
     def initialize(self, *args, **kwargs):
         self._context_persistence_excludes = (
@@ -1069,8 +1068,8 @@ class Algorithm(object):
 
     @api_method
     def pipeline_output(self, name):
-        if self._pipeline_hook is not None:
-            return self._pipeline_hook(self, name)
+        if self._pipeline_hook:
+            return self._pipeline_hook.output(self, name)
 
         try:
             from pipeline_live.engine import LivePipelineEngine

--- a/pylivetrader/testing/smoke/harness.py
+++ b/pylivetrader/testing/smoke/harness.py
@@ -52,13 +52,8 @@ def run_smoke(algo, before_run_hook=None, pipeline_hook=None):
         handle_data=getattr(algo, 'handle_data', noop),
         before_trading_start=getattr(algo, 'before_trading_start', noop),
         backend=be,
+        pipeline_hook=pipeline_hook
     )
-
-    if pipeline_hook is not None:
-        def _pipeline_output(name):
-            return pipeline_hook.output(a, name)
-
-        a.pipeline_output = _pipeline_output
 
     with LiveTraderAPI(a), \
             patch('pylivetrader.executor.executor.RealtimeClock') as rc:


### PR DESCRIPTION
algorithm \_\_setattr\_\_  prevents us from hooking the pipeline output to run locally.
we had this optional argument to the \_\_init\_\_ function to allow us to do that