### PR TITLE
When get_barset() fails try the new get_bars()

### DIFF
--- a/pylivetrader/backend/alpaca.py
+++ b/pylivetrader/backend/alpaca.py
@@ -15,7 +15,7 @@
 
 import alpaca_trade_api as tradeapi
 from alpaca_trade_api import Stream
-from alpaca_trade_api.rest import APIError
+from alpaca_trade_api.rest import APIError, TimeFrame
 from alpaca_trade_api.entity import Order
 from requests.exceptions import HTTPError
 import numpy as np
@@ -651,8 +651,19 @@ class Backend(BaseBackend):
                                       start=_from.isoformat(),
                                       end=to.isoformat()).df[symbols]
 
-            # zipline -> right label
-            # API result -> left label (beginning of bucket)
+            if not df.empty:
+                # we got an empty response. We will try to use the updated
+                # V2 api to get the data. we cannot do 1 api call for all
+                # symbols so we will iterate them
+                r = {}
+                for sym in symbols:
+                    r[sym] = self._api.get_bars(sym, TimeFrame.Minute,
+                                                _from.isoformat(),
+                                                to.isoformat(),
+                                                adjustment='raw').df
+                df = pd.concat(r, axis=1)
+                # data is received in UTC tz but without tz (naive)
+                df.index = df.index.tz_localize("UTC")
             if size == 'minute':
                 df.index += pd.Timedelta('1min')
 

--- a/pylivetrader/backend/alpaca.py
+++ b/pylivetrader/backend/alpaca.py
@@ -651,7 +651,7 @@ class Backend(BaseBackend):
                                       start=_from.isoformat(),
                                       end=to.isoformat()).df[symbols]
 
-            if not df.empty:
+            if df.empty:
                 # we got an empty response. We will try to use the updated
                 # V2 api to get the data. we cannot do 1 api call for all
                 # symbols so we will iterate them


### PR DESCRIPTION
currently get_barset() is deprecated but still works.
it's more efficient than get_bars() since we could get data for 200 equities with one api call.
once the endpoint stops working we will move all calls to data v2