### PR TITLE
Quick fixes to remove calls to market data v1 from alpaca SDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,11 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            python3 setup.py flake8 test
+            python3 setup.py
+            pip install -R requirements/requirements.txt
+            pip install -R requirements/requirements_test.txt
+            flake8 ./pylivetrader
+            pytest
 
   build-python37:
     docker:
@@ -43,7 +47,11 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            python3 setup.py flake8 test
+            python3 setup.py
+            pip install -R requirements/requirements.txt
+            pip install -R requirements/requirements_test.txt
+            flake8 ./pylivetrader
+            pytest
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            pip install -r requirements/requirements.txt
             pip install -r requirements/requirements_test.txt
             flake8 ./pylivetrader
             pytest
@@ -46,7 +45,6 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            pip install -r requirements/requirements.txt
             pip install -r requirements/requirements_test.txt
             flake8 ./pylivetrader
             pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            pip install -R requirements/requirements.txt
-            pip install -R requirements/requirements_test.txt
+            pip install -r requirements/requirements.txt
+            pip install -r requirements/requirements_test.txt
             flake8 ./pylivetrader
             pytest
 
@@ -46,8 +46,8 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            pip install -R requirements/requirements.txt
-            pip install -R requirements/requirements_test.txt
+            pip install -r requirements/requirements.txt
+            pip install -r requirements/requirements_test.txt
             flake8 ./pylivetrader
             pytest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: |
             . venv/bin/activate
             pip install -r requirements/requirements_test.txt
-            flake8 ./pylivetrader
+            flake8 ./pylivetrader && echo "Flake8 passed"
             pytest
 
   build-python37:
@@ -46,7 +46,7 @@ jobs:
           command: |
             . venv/bin/activate
             pip install -r requirements/requirements_test.txt
-            flake8 ./pylivetrader
+            flake8 ./pylivetrader && echo "Flake8 passed"
             pytest
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            python3 setup.py
             pip install -R requirements/requirements.txt
             pip install -R requirements/requirements_test.txt
             flake8 ./pylivetrader
@@ -47,7 +46,6 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            python3 setup.py
             pip install -R requirements/requirements.txt
             pip install -R requirements/requirements_test.txt
             flake8 ./pylivetrader

--- a/pylivetrader/_version.py
+++ b/pylivetrader/_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = '0.6.0'
+VERSION = '0.7.0'

--- a/pylivetrader/backend/alpaca.py
+++ b/pylivetrader/backend/alpaca.py
@@ -15,7 +15,7 @@
 
 import alpaca_trade_api as tradeapi
 from alpaca_trade_api import Stream
-from alpaca_trade_api.rest import APIError, TimeFrame, TimeFrameUnit
+from alpaca_trade_api.rest import APIError, TimeFrame
 from alpaca_trade_api.entity import Order
 from requests.exceptions import HTTPError
 import numpy as np
@@ -646,8 +646,7 @@ class Backend(BaseBackend):
             to = params['to']
             size = params['size']
 
-            timeframe = TimeFrame(1, TimeFrameUnit.Minute) if size == "minute"\
-                else TimeFrame(1, TimeFrameUnit.Day)
+            timeframe = TimeFrame.Minute if size == "minute" else TimeFrame.Day
 
             # Using V2 api to get the data. we cannot do 1 api call for all
             # symbols because the v1 `limit` was per symbol, where v2 it's for

--- a/pylivetrader/backend/alpaca.py
+++ b/pylivetrader/backend/alpaca.py
@@ -446,7 +446,7 @@ class Backend(BaseBackend):
             return
 
     def get_last_traded_dt(self, asset):
-        trade = self._api.get_last_trade(asset.symbol)
+        trade = self._api.get_latest_trade(asset.symbol)
         return trade.timestamp
 
     def get_spot_value(
@@ -496,7 +496,7 @@ class Backend(BaseBackend):
 
         @skip_http_error((404, 504))
         def fetch(symbol):
-            return self._api.get_last_trade(symbol)
+            return self._api.get_latest_trade(symbol)
 
         return parallelize(fetch)(symbols)
 

--- a/pylivetrader/backend/alpaca.py
+++ b/pylivetrader/backend/alpaca.py
@@ -646,7 +646,7 @@ class Backend(BaseBackend):
             to = params['to']
             size = params['size']
 
-            timeframe = TimeFrame(1, TimeFrameUnit.Minute) if size == "minute" \
+            timeframe = TimeFrame(1, TimeFrameUnit.Minute) if size == "minute"\
                 else TimeFrame(1, TimeFrameUnit.Day)
 
             # Using V2 api to get the data. we cannot do 1 api call for all

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,6 +10,6 @@ trading_calendars>=1.11
 click==8.0.1
 PyYAML>=5, <6
 ipython>=7
-alpaca-trade-api>=1.2.2
+alpaca-trade-api==1.5.0
 pandas>=0.18.1, <=0.22.0  # pyup: ignore # limit to work properly with zipline 1.3.0
 pandas-datareader<=0.8.1  # pyup: ignore # higher requires pandas>=0.23, zipline limits to 0.22

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -1,2 +1,3 @@
 pytest>=5.0.0
 pytest-cov
+flake8


### PR DESCRIPTION
Bumps requirement on alpaca-trade-api to 1.5.0, going even to 1.5.1 causes:
```
The conflict is caused by:
    The user requested PyYAML<6 and >=5
    alpaca-trade-api 1.5.1 depends on PyYAML==6.0
```
to be reported by pip, not sure why we have the hardcoded requirement to be less than 6 but rather than going down that rabbit hole here, 1.5.0 gets us close enough to recent that we can leave solving these issues to the future.

Also changes the circle ci integration to use pip to install flake8 and pytest, the flake8 setuptools integration no longer works so it just errors out.